### PR TITLE
feat: Implement server-side filtering and pagination

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -135,8 +135,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const limit = parseInt(req.query.limit as string) || 20;
       const offset = parseInt(req.query.offset as string) || 0;
       const categoryId = req.query.categoryId as string;
-      
-      const predictions = await storage.getPredictions(limit, offset, categoryId);
+      const sortBy = req.query.sortBy as "recent" | "trending" | "ending_soon";
+      const searchQuery = req.query.searchQuery as string;
+
+      const predictions = await storage.getPredictions(limit, offset, categoryId, sortBy, searchQuery);
       
       // If user is authenticated, include their votes
       if (req.session && (req.session as any).userId) {


### PR DESCRIPTION
This change refactors the prediction feed on the Explore page to be more scalable and performant.

Previously, the frontend fetched a single large batch of predictions and performed all filtering, sorting, and searching on the client side. This was inefficient and did not scale.

This commit introduces the following changes:

- The backend `getPredictions` function in `server/storage.ts` now accepts `sortBy` and `searchQuery` parameters and performs these operations at the database level.
- The frontend `Explore` page in `client/src/pages/explore.tsx` has been refactored to use `useInfiniteQuery` from TanStack Query.
- The page now implements infinite scrolling with a "Load More" button.
- All sorting and searching logic is now handled by the backend, and the corresponding client-side logic has been removed.

This provides a much better user experience and a more robust foundation for future features.